### PR TITLE
TR-4781 Add wait for deployment completion feature by checking ECS service stability

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -15,6 +15,7 @@ VERBOSE=false
 TAGVAR=false
 TAGONLY=""
 ENABLE_ROLLBACK=false
+WAIT_COMPLETION=false
 AWS_CLI=$(which aws)
 AWS_ECS="$AWS_CLI --output json ecs"
 
@@ -50,6 +51,7 @@ Optional arguments:
     -to | --tag-only        New tag to apply to all images defined in the task (multi-container task). If provided this will override value specified in image name argument.
     --max-definitions       Number of Task Definition Revisions to persist before deregistering oldest revisions.
     --enable-rollback       Rollback task definition if new version is not running before TIMEOUT
+    --wait-completion       Wait for the full deployment completion by checking if the service is stable
     -v | --verbose          Verbose output
          --version          Display the version
 
@@ -407,6 +409,33 @@ function waitForGreenDeployment {
   fi
 }
 
+function waitForDeplomentCompletion {
+  echo "Waiting for deployment completion until service is stable"
+
+  WAIT="true"
+  DEPLOYMENT_SUCCESS="false"
+  
+  while [ "${WAIT}" != "false" ]
+  do
+
+    if NEW_DEPLOYMENT=$($AWS_ECS wait services-stable --cluster $CLUSTER --services $SERVICE); then
+      DEPLOYMENT_SUCCESS="true"
+      WAIT="false"
+      echo "Deployment completed successfully"
+    else
+      WAIT="false"
+      echo "Deployment timeout"
+    fi
+  done
+
+  if [[ "${DEPLOYMENT_SUCCESS}" != "true" ]]; then
+    if [[ "${ENABLE_ROLLBACK}" != "false" ]]; then
+      rollback
+    fi
+    exit 1
+  fi
+}
+
 ######################################################
 # When not being tested, run application as expected #
 ######################################################
@@ -500,6 +529,9 @@ if [ "$BASH_SOURCE" == "$0" ]; then
             --enable-rollback)
                 ENABLE_ROLLBACK=true
                 ;;
+            --wait-completion)
+                WAIT_COMPLETION=true
+                ;;
             -v|--verbose)
                 VERBOSE=true
                 ;;
@@ -549,7 +581,11 @@ if [ "$BASH_SOURCE" == "$0" ]; then
     else
         updateService
 
-        waitForGreenDeployment
+      if [ $WAIT_COMPLETION == true ]; then
+          waitForDeplomentCompletion
+      else
+          waitForGreenDeployment
+      fi
     fi
 
     if [[ "$AWS_ASSUME_ROLE" != false ]]; then

--- a/ecs-deploy
+++ b/ecs-deploy
@@ -418,7 +418,12 @@ function waitForDeplomentCompletion {
   while [ "${WAIT}" != "false" ]
   do
 
-    if NEW_DEPLOYMENT=$($AWS_ECS wait services-stable --cluster $CLUSTER --services $SERVICE); then
+    set +e
+    $AWS_ECS wait services-stable --cluster $CLUSTER --services $SERVICE
+    DEPLOYMENT_EXIT_CODE=$(echo $?)
+    set -e
+
+    if [[ "$DEPLOYMENT_EXIT_CODE" == 0 ]]; then
       DEPLOYMENT_SUCCESS="true"
       WAIT="false"
       echo "Deployment completed successfully"


### PR DESCRIPTION
## Description

To add smoke tests to our ECS deployment pipelines, we need a way to ensure the deployment has successfully completed and tasks have been replaced before running the smoke tests. 

This PR adds a wait-for-deployment completion feature by checking the ECS service stability using the [services-stable ](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html#services-stable) command. This waits for the new task definition to reach the desired task count and also for the deregistration delay to finish so that we don't have old tasks still running. 

A few notes
- The script already has the `timeout` that waits for a fixed time period before deciding whether the deployment has failed or not. I didn't change that existing feature because I'd like to test the `--wait-completion` feature in our pipelines first. Maybe they can coexist? let me know what you think
- The `service-stable` command has a timeout after 40 failed checks, which is 10 min. This might not be enough for FD, so we would need to retry the command. I can work on adding that after testing this on smaller services first.  

## Verification steps

You can deploy an ECS service manually using the following command 
```
 ./ecs-deploy -r REGION -c CLUSTER -n SERVICE -i IMAGE --wait-completion
```

