### PR TITLE
TR-4879 retry when 'ecs wait services-stable' times out

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -436,6 +436,9 @@ function waitForDeplomentCompletion {
 
   WAIT="true"
   DEPLOYMENT_SUCCESS="false"
+  RETRIES=0
+  MAX_RETRIES=10
+  RETRY_STEP=1
   
   while [ "${WAIT}" != "false" ]
   do
@@ -450,8 +453,13 @@ function waitForDeplomentCompletion {
       WAIT="false"
       echo "Deployment completed successfully"
     else
-      WAIT="false"
-      echo "Deployment timeout"
+      if [[ $RETRIES -lt $MAX_RETRIES ]]; then
+          echo "Still waiting for deployment completion"
+          RETRIES=$(( $RETRIES + $RETRY_STEP ))
+      else
+          WAIT="false"
+          echo "Deployment timeout"
+      fi
     fi
   done
 


### PR DESCRIPTION
## Description

The `ecs wait services-stable` command has a timeout of 10 min, which is not enough when deploying large ECS services. This PR makes the script retry 9 times (meaning 90 minutes waiting for the deployment in total) before actually failing the script.   https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html

What we're currently seeing:
```
Waiting for deployment completion until service is stable

Waiter ServicesStable failed: Max attempts exceeded
Deployment timeout
```